### PR TITLE
add AuditEvent example #38

### DIFF
--- a/fsh-generated/resources/AuditEvent-ex-auditProvideBundle-source.json
+++ b/fsh-generated/resources/AuditEvent-ex-auditProvideBundle-source.json
@@ -1,0 +1,162 @@
+{
+  "resourceType": "AuditEvent",
+  "id": "ex-auditProvideBundle-source",
+  "meta": {
+    "security": [
+      {
+        "code": "HTEST",
+        "system": "http://terminology.hl7.org/CodeSystem/v3-ActReason"
+      }
+    ],
+    "profile": [
+      "http://profiles.ihe.net/ITI/MHD/StructureDefinition/IHE.MHD.ProvideBundle.Audit.Source"
+    ]
+  },
+  "type": {
+    "system": "http://dicom.nema.org/resources/ontology/DCM",
+    "code": "110106",
+    "display": "Export"
+  },
+  "agent": [
+    {
+      "type": {
+        "coding": [
+          {
+            "system": "http://dicom.nema.org/resources/ontology/DCM",
+            "code": "110153",
+            "display": "Source Role ID"
+          }
+        ]
+      },
+      "who": {
+        "display": "ihe-sourceId"
+      },
+      "requestor": false,
+      "network": {
+        "address": "myDevice.example.com",
+        "type": "1"
+      }
+    },
+    {
+      "type": {
+        "coding": [
+          {
+            "system": "http://dicom.nema.org/resources/ontology/DCM",
+            "code": "110152",
+            "display": "Destination Role ID"
+          }
+        ]
+      },
+      "requestor": false,
+      "who": {
+        "display": "myMachine.example.org"
+      },
+      "network": {
+        "address": "http://server.example.com/fhir",
+        "type": "5"
+      }
+    },
+    {
+      "type": {
+        "coding": [
+          {
+            "code": "PROV",
+            "system": "http://terminology.hl7.org/CodeSystem/v3-RoleClass",
+            "display": "healthcare provider"
+          }
+        ]
+      },
+      "role": [
+        {
+          "coding": [
+            {
+              "code": "HCP",
+              "system": "urn:oid:2.16.756.5.30.1.127.3.10.6",
+              "display": "Healthcare professional"
+            }
+          ]
+        }
+      ],
+      "name": "Martina Musterarzt",
+      "requestor": true,
+      "who": {
+        "identifier": {
+          "system": "urn:gs1:gln",
+          "value": "2000000090108"
+        }
+      },
+      "policy": [
+        "c5436729-3f26-4dbf-abd3-2790dc7771a"
+      ]
+    }
+  ],
+  "entity": [
+    {
+      "type": {
+        "system": "http://terminology.hl7.org/CodeSystem/audit-entity-type",
+        "code": "1",
+        "display": "Person"
+      },
+      "role": {
+        "code": "1",
+        "system": "http://terminology.hl7.org/CodeSystem/object-role",
+        "display": "Patient"
+      },
+      "what": {
+        "reference": "http://example.org/Patient/FranzMusterNeedsAbsoluteUrl"
+      }
+    },
+    {
+      "type": {
+        "system": "http://terminology.hl7.org/CodeSystem/audit-entity-type",
+        "code": "2",
+        "display": "System Object"
+      },
+      "role": {
+        "code": "20",
+        "system": "http://terminology.hl7.org/CodeSystem/object-role",
+        "display": "Job"
+      },
+      "what": {
+        "identifier": {
+          "system": "urn:ietf:rfc:3986",
+          "value": "urn:oid:1.3.6.1.4.1.12559.11.13.2.6.2949"
+        }
+      }
+    }
+  ],
+  "action": "R",
+  "subtype": [
+    {
+      "code": "ITI-65",
+      "system": "urn:ihe:event-type-code",
+      "display": "Provide Document Bundle"
+    }
+  ],
+  "recorded": "2020-06-29T12:01:30+00:00",
+  "outcome": "0",
+  "purposeOfEvent": [
+    {
+      "coding": [
+        {
+          "code": "NORM",
+          "system": "urn:oid:2.16.756.5.30.1.127.3.10.5",
+          "display": "Normal Access"
+        }
+      ]
+    }
+  ],
+  "source": {
+    "site": "urn:oid:1.3.6.1.4.1.12559.11.13.2.5",
+    "observer": {
+      "display": "ihe-sourceId"
+    },
+    "type": [
+      {
+        "code": "1",
+        "system": "http://terminology.hl7.org/CodeSystem/security-source-type",
+        "display": "User Device"
+      }
+    ]
+  }
+}

--- a/input/ch.fhir.ig.ch-epr-mhealth.xml
+++ b/input/ch.fhir.ig.ch-epr-mhealth.xml
@@ -34,6 +34,11 @@
   <packageId value="ch.fhir.ig.ch-epr-mhealth"/>
   <license value="CC-BY-SA-4.0"/>
   <fhirVersion value="4.0.1"/>
+  <dependsOn id="chterm">
+    <uri value="http://fhir.ch/ig/ch-epr-term/ImplementationGuide/ch.fhir.ig.ch-epr-term"/>
+    <packageId value="ch.fhir.ig.ch-epr-term"/>
+    <version value="2.0.5"/>
+  </dependsOn>
   <dependsOn id="chcore">
     <uri value="http://fhir.ch/ig/ch-core/ImplementationGuide/ch.fhir.ig.ch-core"/>
     <packageId value="ch.fhir.ig.ch-core"/>
@@ -139,6 +144,14 @@
       <name value="MHD Find DocumentReferences"/>
       <description value="MHD Find DocumentReferences - Bundle as Response"/>
       <exampleCanonical value="http://fhir.ch/ig/ch-epr-mhealth/StructureDefinition/ch-mhd-documentreference-comprehensive-bundle"/>
+    </resource>
+    <resource>
+      <reference>
+        <reference value="AuditEvent/ex-auditProvideBundle-source"/>
+      </reference>
+      <name value="Audit Event for Provide Bundle Transaction at Source"/>
+      <description value="Audit Example for a Provide Bundle Transaction from source perspective"/>
+      <exampleCanonical value="http://profiles.ihe.net/ITI/MHD/StructureDefinition/IHE.MHD.ProvideBundle.Audit.Source"/>
     </resource>
 
     <!-- CH EPR mHealth: Resource Profiles -->

--- a/input/fsh/Aliases.fsh
+++ b/input/fsh/Aliases.fsh
@@ -1,0 +1,2 @@
+Alias: ReasonCodeExtension = http://hl7.org/fhir/StructureDefinition/workflow-reasonCode
+Alias: DCM = http://dicom.nema.org/resources/ontology/DCM

--- a/input/fsh/ex-audit-65.fsh
+++ b/input/fsh/ex-audit-65.fsh
@@ -1,0 +1,45 @@
+Instance: ex-auditProvideBundle-source
+InstanceOf: IHE.MHD.ProvideBundle.Audit.Source
+Title: "Audit Example of ITI-65 at source"
+Description: "Audit Example for a Provide Bundle Transaction from source perspective"
+Usage: #example
+* meta.security = http://terminology.hl7.org/CodeSystem/v3-ActReason#HTEST
+* type = DCM#110106 "Export"
+* action = #R
+* subtype = urn:ihe:event-type-code#ITI-65 "Provide Document Bundle"
+//* severity = #Informational
+* recorded = 2020-06-29T12:01:30+00:00
+* outcome = http://terminology.hl7.org/CodeSystem/audit-event-outcome#0 "Success"
+* purposeOfEvent = urn:oid:2.16.756.5.30.1.127.3.10.5#NORM "Normal Access"
+* source.site = "urn:oid:1.3.6.1.4.1.12559.11.13.2.5"
+* source.observer.display = "ihe-sourceId"
+* source.type = http://terminology.hl7.org/CodeSystem/security-source-type#1 "User Device"
+// documentSender
+* agent[0].type = DCM#110153 "Source Role ID"
+* agent[0].who.display = "ihe-sourceId"
+* agent[0].requestor = false
+* agent[0].network.address = "myDevice.example.com"
+* agent[0].network.type = http://hl7.org/fhir/network-type#1 "domain name"
+// documentRecipeint
+* agent[1].type = DCM#110152 "Destination Role ID"
+* agent[1].requestor = false
+* agent[1].who.display = "myMachine.example.org"
+* agent[1].network.address = "http://server.example.com/fhir"
+* agent[1].network.type = http://hl7.org/fhir/network-type#5 "URI"
+// user
+* agent[2].type = http://terminology.hl7.org/CodeSystem/v3-RoleClass#PROV "healthcare provider" // the user is the hcp
+* agent[2].role = urn:oid:2.16.756.5.30.1.127.3.10.6#HCP "Healthcare professional"
+* agent[2].name = "Martina Musterarzt"
+* agent[2].requestor = true
+* agent[2].who.identifier.system = "urn:gs1:gln"
+* agent[2].who.identifier.value = "2000000090108"
+// iua token jit
+* agent[2].policy[0] = "c5436729-3f26-4dbf-abd3-2790dc7771a"
+* entity[patient].type = http://terminology.hl7.org/CodeSystem/audit-entity-type#1 "Person"
+* entity[patient].role = http://terminology.hl7.org/CodeSystem/object-role#1 "Patient"
+* entity[patient].what = Reference(http://example.org/Patient/FranzMusterNeedsAbsoluteUrl)
+* entity[submissionSet].type = http://terminology.hl7.org/CodeSystem/audit-entity-type#2 "System Object"
+* entity[submissionSet].role = http://terminology.hl7.org/CodeSystem/object-role#20 "Job"
+* entity[submissionSet].what.identifier.system = "urn:ietf:rfc:3986"
+* entity[submissionSet].what.identifier.value = "urn:oid:1.3.6.1.4.1.12559.11.13.2.6.2949"
+

--- a/input/pagecontent/iti-20.md
+++ b/input/pagecontent/iti-20.md
@@ -33,3 +33,5 @@ Same message semantics and expected actions apply as described in the ITI-20 tra
 ### Security Consideration
 
 TLS SHALL be used. 
+
+[Audit Example for a Provide Bundle Transaction from source perspective](AuditEvent-ex-auditProvideBundle-source.html).

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -1,0 +1,12 @@
+id: ch.fhir.ig.ch-epr-mhealth
+canonical: http://fhir.ch/ig/ch-epr-mhealth/ImplementationGuide/ch.fhir.ig.ch-epr-mhealth
+name: CHEprMhealth
+fhirVersion: 4.0.1
+status: active
+copyrightYear: 2020+
+releaseLabel: ci-build
+dependencies:
+  ch.fhir.ig.ch-epr-term: 2.0.5
+  ch.fhir.ig.ch-core: 2.0.0
+  IHE.ITI.PIXm: 3.0.0
+  ihe.mhd.fhir: 4.0.2


### PR DESCRIPTION
- The IHE MHD and PIXm base IG's have added now examples.
- There is a ITI.BasicAudit in development which describes how to map between XUA/IUA to the AuditEvent resource

This PR adds one example to show how an AuditEvent can be generated according to IHE MHD / IUA