### PR TITLE
ITI-65: prevent providing patients in request

### DIFF
--- a/input/pagecontent/openissues.md
+++ b/input/pagecontent/openissues.md
@@ -1,3 +1,7 @@
+### DSTU3 Informative Ballot 2023 - Resolved Issues
+
+* Disallow non-contained Patient resources in ITI-65 requests [#75](https://github.com/ehealthsuisse/ch-epr-mhealth/issues/75)
+
 ### DSTU3 Informative Ballot 2023 - Raised Issues
 
 The implementation guide was under an informative ballot by HL7 Switzerland until September 30th, 2023. The following comments have been raised

--- a/input/resources/structuredefinition/ch-mhd-providedocumentbundle-comprehensive.xml
+++ b/input/resources/structuredefinition/ch-mhd-providedocumentbundle-comprehensive.xml
@@ -157,5 +157,11 @@
             <min value="0"/>
             <max value="0"/>
         </element>
+
+        <element id="Bundle.entry:Patient">
+            <path value="Bundle.entry"/>
+            <sliceName value="Patient"/>
+            <max value="0"/>
+        </element>
     </differential>
 </StructureDefinition>


### PR DESCRIPTION
We can put the Patient slice to zero, because the DocumentReference.patient needs to point to an external patient and the sourcePatientInfo is contained in the DocumentResource.

Part of #75