### PR TITLE
Fix PDQm Supplier CapabilityStatement in CH.mHealth.API

### DIFF
--- a/input/pagecontent/openissues.md
+++ b/input/pagecontent/openissues.md
@@ -1,7 +1,6 @@
 ### DSTU3 Informative Ballot 2023 - Resolved Issues
 
-### Added
-
+* PDQm Supplier actor name misspelled in mHealth API CapabilityStatement [#87](https://github.com/ehealthsuisse/ch-epr-mhealth/issues/87)
 * Missing Swiss specific PDQ V3 Error message in PDQm [#80](https://github.com/ehealthsuisse/ch-epr-mhealth/issues/80)
 * Disallow non-contained Patient resources in ITI-65 requests [#75](https://github.com/ehealthsuisse/ch-epr-mhealth/issues/75)
 

--- a/input/resources/capabilitystatement/CH.mHealth.API.xml
+++ b/input/resources/capabilitystatement/CH.mHealth.API.xml
@@ -16,7 +16,7 @@
     <description value="CapabilityStatement for mHealth API (server)." />
     <kind value="requirements" />
     <imports value="http://fhir.ch/ig/ch-epr-mhealth/CapabilityStatement/CH.PIXm.Manager"/>
-    <imports value="http://fhir.ch/ig/ch-epr-mhealth/CapabilityStatement/CH.PIXm.Supplier"/>
+    <imports value="http://fhir.ch/ig/ch-epr-mhealth/CapabilityStatement/CH.PDQm.Supplier"/>
     <imports value="http://fhir.ch/ig/ch-epr-mhealth/CapabilityStatement/CH.MHD.DocumentRecipient"/>
     <imports value="http://fhir.ch/ig/ch-epr-mhealth/CapabilityStatement/CH.MHD.DocumentResponder"/>
     <fhirVersion value="4.0.1" />


### PR DESCRIPTION
The PDQm Supplier role was misspelled as PIXm Supplier in the mHealth API CapabilityStatement.

Fixes #87

Changelog to add:

> PDQm Supplier actor name misspelled in mHealth API CapabilityStatemenet [#87](https://github.com/ehealthsuisse/ch-epr-mhealth/issues/87)