### PR TITLE
Add missing mCSD CapabilityStatement imports in mHealth App and API

### DIFF
--- a/input/pagecontent/openissues.md
+++ b/input/pagecontent/openissues.md
@@ -1,5 +1,6 @@
 ### DSTU3 Informative Ballot 2023 - Resolved Issues
 
+* Add missing mCSD CapabilityStatement imports in mHealth App and API [#70](https://github.com/ehealthsuisse/ch-epr-mhealth/issues/70)
 * PDQm Supplier actor name misspelled in mHealth API CapabilityStatement [#87](https://github.com/ehealthsuisse/ch-epr-mhealth/issues/87)
 * Missing Swiss specific PDQ V3 Error message in PDQm [#80](https://github.com/ehealthsuisse/ch-epr-mhealth/issues/80)
 * Disallow non-contained Patient resources in ITI-65 requests [#75](https://github.com/ehealthsuisse/ch-epr-mhealth/issues/75)

--- a/input/resources/capabilitystatement/CH.mHealth.API.xml
+++ b/input/resources/capabilitystatement/CH.mHealth.API.xml
@@ -19,6 +19,7 @@
     <imports value="http://fhir.ch/ig/ch-epr-mhealth/CapabilityStatement/CH.PDQm.Supplier"/>
     <imports value="http://fhir.ch/ig/ch-epr-mhealth/CapabilityStatement/CH.MHD.DocumentRecipient"/>
     <imports value="http://fhir.ch/ig/ch-epr-mhealth/CapabilityStatement/CH.MHD.DocumentResponder"/>
+    <imports value="http://fhir.ch/ig/ch-epr-mhealth/CapabilityStatement/CH.mCSD.CareServicesSelectiveSupplier"/>
     <fhirVersion value="4.0.1" />
     <format value="application/fhir+xml" />
     <format value="application/fhir+json" />

--- a/input/resources/capabilitystatement/CH.mHealth.App.xml
+++ b/input/resources/capabilitystatement/CH.mHealth.App.xml
@@ -20,6 +20,7 @@
     <imports value="http://fhir.ch/ig/ch-epr-mhealth/CapabilityStatement/CH.PIXm.Source"/>
     <imports value="http://fhir.ch/ig/ch-epr-mhealth/CapabilityStatement/CH.MHD.DocumentSource"/>
     <imports value="http://fhir.ch/ig/ch-epr-mhealth/CapabilityStatement/CH.MHD.DocumentConsumer"/>
+    <imports value="http://fhir.ch/ig/ch-epr-mhealth/CapabilityStatement/CH.mCSD.CareServicesSelectiveConsumer"/>
     <fhirVersion value="4.0.1" />
     <format value="application/fhir+xml" />
     <format value="application/fhir+json" />


### PR DESCRIPTION
For App, add CH.mCSD.CareServicesSelectiveConsumer. For API, add  CH.mCSD.CareServicesSelectiveSupplier. Fixes #70
