### PR TITLE
additional bindings doc ref (origin PR from JV, additions from MZ)

### DIFF
--- a/input/fsh/Aliases.fsh
+++ b/input/fsh/Aliases.fsh
@@ -42,3 +42,4 @@ Alias: $ch-mhd-documentreference-comprehensive = http://fhir.ch/ig/ch-epr-fhir/S
 Alias: $ch-mhd-documentreference-comprehensive = http://fhir.ch/ig/ch-epr-fhir/StructureDefinition/ch-mhd-documentreference-comprehensive
 Alias: $SubmissionSet.contentTypeCode = http://fhir.ch/ig/ch-term/ValueSet/SubmissionSet.contentTypeCode
 Alias: $purposeOfUse = urn:oid:2.16.756.5.30.1.127.3.10.5
+Alias: $add-binding = http://hl7.org/fhir/tools/StructureDefinition/additional-binding

--- a/input/fsh/mhd.fsh
+++ b/input/fsh/mhd.fsh
@@ -295,7 +295,9 @@ Description: "CH MHD SubmissionSet Comprehensive"
 
 RuleSet: AdditionalBinding(profile, elementPath, usagePath, usageCategory, valueSet, binding)
 * {elementPath} ^binding.extension[+].url = $add-binding
-* {elementPath} ^binding.extension[=].extension[0].url = "purpose"
+* {elementPath} ^binding.extension[=].extension[0].url = "key"
+* {elementPath} ^binding.extension[=].extension[=].valueId = category-to-type
+* {elementPath} ^binding.extension[=].extension[+].url = "purpose"
 * {elementPath} ^binding.extension[=].extension[=].valueCode = #{binding}
 * {elementPath} ^binding.extension[=].extension[+].url = "valueSet"
 * {elementPath} ^binding.extension[=].extension[=].valueCanonical = Canonical({valueSet})

--- a/input/fsh/mhd.fsh
+++ b/input/fsh/mhd.fsh
@@ -292,7 +292,6 @@ Description: "CH MHD SubmissionSet Comprehensive"
 
 
 
-
 RuleSet: AdditionalBinding(profile, elementPath, usagePath, usageCategory, valueSet, binding)
 * {elementPath} ^binding.extension[+].url = $add-binding
 * {elementPath} ^binding.extension[=].extension[0].url = "key"

--- a/input/fsh/mhd.fsh
+++ b/input/fsh/mhd.fsh
@@ -302,8 +302,7 @@ RuleSet: AdditionalBinding(profile, elementPath, usagePath, usageCategory, value
 * {elementPath} ^binding.extension[=].extension[+].url = "usage"
 * {elementPath} ^binding.extension[=].extension[=].valueUsageContext.code.system = Canonical({profile})
 * {elementPath} ^binding.extension[=].extension[=].valueUsageContext.code.code = #{usagePath}
-* {elementPath} ^binding.extension[=].extension[=].valueUsageContext.valueCodeableConcept = $sct#{usageCategory} // This is not official display. Need to support display? "{profile} {usageCategory} ValueSet"
-* {elementPath} ^binding.extension[=].extension[=].valueUsageContext.valueCodeableConcept.text = "{usageCategory}"
+* {elementPath} ^binding.extension[=].extension[=].valueUsageContext.valueCodeableConcept = $sct#{usageCategory}
 
 // Group 1 — 371531000 Report of clinical encounter
 ValueSet: VS_DocType_371531000

--- a/input/fsh/mhd.fsh
+++ b/input/fsh/mhd.fsh
@@ -312,6 +312,7 @@ Id: doccategory-371531000
 Title: "DocType for DocCategory 371531000"
 Description: "Target typeCodes for classCode SCT 371531000 (Report of clinical encounter)"
 * ^status = #active
+* ^experimental = false
 * $sct#371530004
 * $sct#371529009
 * $sct#371532007
@@ -323,6 +324,7 @@ Id: doccategory-721927009
 Title: "DocType for DocCategory 721927009"
 Description: "Target typeCodes for classCode SCT 721927009 (Referral note)"
 * ^status = #active
+* ^experimental = false
 * $sct#419891008
 
 // Group 3 — 721963009 Order
@@ -331,6 +333,7 @@ Id: doccategory-721963009
 Title: "DocType for DocCategory 721963009"
 Description: "Target typeCodes for classCode SCT 721963009 (Order)"
 * ^status = #active
+* ^experimental = false
 * $sct#721965002
 * $sct#721966001
 * $sct#2161000195103
@@ -342,6 +345,7 @@ Id: doccategory-422735006
 Title: "DocType for DocCategory 422735006"
 Description: "Target typeCodes for classCode SCT 422735006 (Summary clinical document)"
 * ^status = #active
+* ^experimental = false
 * $sct#373942005
 * $sct#371535009
 * $sct#721912009
@@ -354,6 +358,7 @@ Id: doccategory-371525003
 Title: "DocType for DocCategory 371525003"
 Description: "Target typeCodes for classCode SCT 371525003 (Clinical procedure report)"
 * ^status = #active
+* ^experimental = false
 * $sct#371526002
 * $sct#4241000179101
 * $sct#371528001
@@ -368,6 +373,7 @@ Id: doccategory-734163000
 Title: "DocType for DocCategory 734163000"
 Description: "Target typeCodes for classCode SCT 734163000 (Care plan)"
 * ^status = #active
+* ^experimental = false
 * $sct#737427001
 * $sct#773130005
 * $sct#736055001
@@ -380,6 +386,7 @@ Id: doccategory-440545006
 Title: "DocType for DocCategory 440545006"
 Description: "Target typeCodes for classCode SCT 440545006 (Prescription record)"
 * ^status = #active
+* ^experimental = false
 * $sct#761938008
 * $sct#765492005
 * $sct#419891008
@@ -390,6 +397,7 @@ Id: doccategory-184216000
 Title: "DocType for DocCategory 184216000"
 Description: "Target typeCodes for classCode SCT 184216000 (Patient record type)"
 * ^status = #active
+* ^experimental = false
 * $sct#722446000
 * $sct#41000179103
 * $sct#419891008
@@ -400,6 +408,7 @@ Id: doccategory-371537001
 Title: "DocType for DocCategory 371537001"
 Description: "Target typeCodes for classCode SCT 371537001 (Consent report)"
 * ^status = #active
+* ^experimental = false
 * $sct#419891008
 
 // Group 10 — 371538006 Advance directive report
@@ -408,6 +417,7 @@ Id: doccategory-371538006
 Title: "DocType for DocCategory 371538006"
 Description: "Target typeCodes for classCode SCT 371538006 (Advance directive report)"
 * ^status = #active
+* ^experimental = false
 * $sct#419891008
 
 // Group 11 — 722160009 Audit trail report
@@ -416,6 +426,7 @@ Id: doccategory-722160009
 Title: "DocType for DocCategory 722160009"
 Description: "Target typeCodes for classCode SCT 722160009 (Audit trail report)"
 * ^status = #active
+* ^experimental = false
 * $sct#419891008
 
 // Group 12 — 722216001 Emergency medical identification record
@@ -424,6 +435,7 @@ Id: doccategory-722216001
 Title: "DocType for DocCategory 722216001"
 Description: "Target typeCodes for classCode SCT 722216001 (Emergency medical identification record)"
 * ^status = #active
+* ^experimental = false
 * $sct#419891008
 
 // Group 13 — 772790007 Organ donor card
@@ -432,6 +444,7 @@ Id: doccategory-772790007
 Title: "DocType for DocCategory 772790007"
 Description: "Target typeCodes for classCode SCT 772790007 (Organ donor card)"
 * ^status = #active
+* ^experimental = false
 * $sct#419891008
 
 // Group 14 — 405624007 Administrative documentation
@@ -440,6 +453,7 @@ Id: doccategory-405624007
 Title: "DocType for DocCategory 405624007"
 Description: "Target typeCodes for classCode SCT 405624007 (Administrative documentation)"
 * ^status = #active
+* ^experimental = false
 * $sct#772786005
 * $sct#419891008
 
@@ -449,6 +463,7 @@ Id: doccategory-417319006
 Title: "DocType for DocCategory 417319006"
 Description: "Target typeCodes for classCode SCT 417319006 (Record of health event)"
 * ^status = #active
+* ^experimental = false
 * $sct#445300006
 * $sct#445418005
 * $sct#82291000195104
@@ -460,6 +475,7 @@ Id: doccategory-2171000195109
 Title: "DocType for DocCategory 2171000195109"
 Description: "Target typeCodes for classCode SCT 2171000195109 (Obstetrical record)"
 * ^status = #active
+* ^experimental = false
 * $sct#419891008
 
 // Group 18 — 419891008 Record artifact (self-map)
@@ -468,4 +484,5 @@ Id: doccategory-419891008
 Title: "DocType for DocCategory 419891008"
 Description: "Target typeCodes for classCode SCT 419891008 (Record artifact)"
 * ^status = #active
+* ^experimental = false
 * $sct#419891008

--- a/input/fsh/mhd.fsh
+++ b/input/fsh/mhd.fsh
@@ -148,6 +148,28 @@ be the the one to use in ITI-68 transactions to retrieve the document content."
 * context.related[StudyInstanceUID].identifier only DicomStudyInstanceUidIdentifier
 * context.related[StudyInstanceUID].identifier ^short = "Requirements on XDS-I.b (Swiss context): When a Imaging Document Source provides a document to the Document Repository, it must provide the StudyInstanceUID, found in the to be registered KOS object, in the referenceIdList (urn:ihe:iti:xds:2013:referenceIdList) attribute of the documentEntry metadata."
 
+
+* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, category, DocumentReference.type, 371531000, VS_DocType_371531000, extensible)
+* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, category, DocumentReference.type, 721927009, VS_DocType_721927009, extensible)
+* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, category, DocumentReference.type, 721963009, VS_DocType_721963009, extensible)
+* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, category, DocumentReference.type, 422735006, VS_DocType_422735006, extensible)
+* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, category, DocumentReference.type, 371525003, VS_DocType_371525003, extensible)
+* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, category, DocumentReference.type, 734163000, VS_DocType_734163000, extensible)
+* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, category, DocumentReference.type, 440545006, VS_DocType_440545006, extensible)
+* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, category, DocumentReference.type, 184216000, VS_DocType_184216000, extensible)
+* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, category, DocumentReference.type, 371537001, VS_DocType_371537001, extensible)
+* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, category, DocumentReference.type, 371538006, VS_DocType_371538006, extensible)
+* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, category, DocumentReference.type, 722160009, VS_DocType_722160009, extensible)
+* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, category, DocumentReference.type, 722216001, VS_DocType_722216001, extensible)
+* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, category, DocumentReference.type, 772790007, VS_DocType_772790007, extensible)
+* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, category, DocumentReference.type, 405624007, VS_DocType_405624007, extensible)
+* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, category, DocumentReference.type, 417319006, VS_DocType_417319006, extensible)
+* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, category, DocumentReference.type, 2171000195109, VS_DocType_2171000195109, extensible)
+* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, category, DocumentReference.type, 419891008, VS_DocType_419891008, extensible)
+
+
+
+
 Invariant: ch-mhd
 Description: "The DocumentReference needs to conform to IHE.MHD.Comprehensive.DocumentReference"
 * severity = #error
@@ -270,3 +292,166 @@ Description: "CH MHD SubmissionSet Comprehensive"
 * entry.item MS
 * entry.item ^type.aggregation[0] = #referenced
 * entry.item ^type.aggregation[+] = #bundled
+
+
+
+
+RuleSet: AdditionalBinding(profile, elementPath, usagePath, usageCategory, valueSet, binding)
+* {elementPath} ^binding.extension[+].url = $add-binding
+* {elementPath} ^binding.extension[=].extension[0].url = "purpose"
+* {elementPath} ^binding.extension[=].extension[=].valueCode = #{binding}
+* {elementPath} ^binding.extension[=].extension[+].url = "valueSet"
+* {elementPath} ^binding.extension[=].extension[=].valueCanonical = {valueSet}
+* {elementPath} ^binding.extension[=].extension[+].url = "usage"
+* {elementPath} ^binding.extension[=].extension[=].valueUsageContext.code.system = Canonical({profile})
+* {elementPath} ^binding.extension[=].extension[=].valueUsageContext.code.code = #{usagePath}
+* {elementPath} ^binding.extension[=].extension[=].valueUsageContext.valueCodeableConcept = $sct#{usageCategory} // This is not official display. Need to support display? "{profile} {usageCategory} ValueSet"
+* {elementPath} ^binding.extension[=].extension[=].valueUsageContext.valueCodeableConcept.text = "{usageCategory}"
+
+
+// Group 1 — 371531000 Report of clinical encounter
+ValueSet: VS_DocType_371531000
+Id: vs-doctype-371531000
+Title: "Targets for classCode 371531000 (Report of clinical encounter)"
+* ^status = #active
+* $sct#371530004 "Clinical consultation report"
+* $sct#371529009 "History and physical report"
+* $sct#371532007 "Progress report"
+* $sct#419891008 "Record artifact"
+
+// Group 2 — 721927009 Referral note
+ValueSet: VS_DocType_721927009
+Id: vs-doctype-721927009
+Title: "Targets for classCode 721927009 (Referral note)"
+* ^status = #active
+* $sct#419891008 "Record artifact"
+
+// Group 3 — 721963009 Order
+ValueSet: VS_DocType_721963009
+Id: vs-doctype-721963009
+Title: "Targets for classCode 721963009 (Order)"
+* ^status = #active
+* $sct#721965002 "Laboratory order"
+* $sct#721966001 "Pathology order"
+* $sct#2161000195103 "Imaging order"
+* $sct#419891008 "Record artifact"
+
+// Group 4 — 422735006 Summary clinical document
+ValueSet: VS_DocType_422735006
+Id: vs-doctype-422735006
+Title: "Targets for classCode 422735006 (Summary clinical document)"
+* ^status = #active
+* $sct#373942005 "Discharge summary"
+* $sct#371535009 "Transfer summary report"
+* $sct#721912009 "Medication summary document"
+* $sct#736378000 "Medication management plan"
+* $sct#419891008 "Record artifact"
+
+// Group 5 — 371525003 Clinical procedure report
+ValueSet: VS_DocType_371525003
+Id: vs-doctype-371525003
+Title: "Targets for classCode 371525003 (Clinical procedure report)"
+* ^status = #active
+* $sct#371526002 "Operative report"
+* $sct#4241000179101 "Laboratory report"
+* $sct#371528001 "Pathology report"
+* $sct#4201000179104 "Imaging report"
+* $sct#900000000000471006 "Image reference"
+* $sct#787148009 "Digital representation of specimen"
+* $sct#419891008 "Record artifact"
+
+// Group 6 — 734163000 Care plan
+ValueSet: VS_DocType_734163000
+Id: vs-doctype-734163000
+Title: "Targets for classCode 734163000 (Care plan)"
+* ^status = #active
+* $sct#737427001 "Clinical management plan"
+* $sct#773130005 "Nursing care plan"
+* $sct#736055001 "Rehabilitation care plan"
+* $sct#761931002 "Medication treatment plan report"
+* $sct#419891008 "Record artifact"
+
+// Group 7 — 440545006 Prescription record
+ValueSet: VS_DocType_440545006
+Id: vs-doctype-440545006
+Title: "Targets for classCode 440545006 (Prescription record)"
+* ^status = #active
+* $sct#761938008 "Medicinal prescription record"
+* $sct#765492005 "Non-drug prescription record"
+* $sct#419891008 "Record artifact"
+
+// Group 8 — 184216000 Patient record type
+ValueSet: VS_DocType_184216000
+Id: vs-doctype-184216000
+Title: "Targets for classCode 184216000 (Patient record type)"
+* ^status = #active
+* $sct#722446000 "Allergy record"
+* $sct#41000179103 "Immunization record"
+* $sct#419891008 "Record artifact"
+
+// Group 9 — 371537001 Consent report
+ValueSet: VS_DocType_371537001
+Id: vs-doctype-371537001
+Title: "Targets for classCode 371537001 (Consent report)"
+* ^status = #active
+* $sct#419891008 "Record artifact"
+
+// Group 10 — 371538006 Advance directive report
+ValueSet: VS_DocType_371538006
+Id: vs-doctype-371538006
+Title: "Targets for classCode 371538006 (Advance directive report)"
+* ^status = #active
+* $sct#419891008 "Record artifact"
+
+// Group 11 — 722160009 Audit trail report
+ValueSet: VS_DocType_722160009
+Id: vs-doctype-722160009
+Title: "Targets for classCode 722160009 (Audit trail report)"
+* ^status = #active
+* $sct#419891008 "Record artifact"
+
+// Group 12 — 722216001 Emergency medical identification record
+ValueSet: VS_DocType_722216001
+Id: vs-doctype-722216001
+Title: "Targets for classCode 722216001 (Emergency medical identification record)"
+* ^status = #active
+* $sct#419891008 "Record artifact"
+
+// Group 13 — 772790007 Organ donor card
+ValueSet: VS_DocType_772790007
+Id: vs-doctype-772790007
+Title: "Targets for classCode 772790007 (Organ donor card)"
+* ^status = #active
+* $sct#419891008 "Record artifact"
+
+// Group 14 — 405624007 Administrative documentation
+ValueSet: VS_DocType_405624007
+Id: vs-doctype-405624007
+Title: "Targets for classCode 405624007 (Administrative documentation)"
+* ^status = #active
+* $sct#772786005 "Medical certificate"
+* $sct#419891008 "Record artifact"
+
+// Group 15/16 — 417319006 Record of health event
+ValueSet: VS_DocType_417319006
+Id: vs-doctype-417319006
+Title: "Targets for classCode 417319006 (Record of health event)"
+* ^status = #active
+* $sct#445300006 "Emergency department record"
+* $sct#445418005 "Professional allied to medicine clinical report"
+* $sct#82291000195104 "Medication dispense document"
+* $sct#419891008 "Record artifact"
+
+// Group 17 — 2171000195109 Obstetrical record
+ValueSet: VS_DocType_2171000195109
+Id: vs-doctype-2171000195109
+Title: "Targets for classCode 2171000195109 (Obstetrical record)"
+* ^status = #active
+* $sct#419891008 "Record artifact"
+
+// Group 18 — 419891008 Record artifact (self-map)
+ValueSet: VS_DocType_419891008
+Id: vs-doctype-419891008
+Title: "Targets for classCode 419891008 (Record artifact)"
+* ^status = #active
+* $sct#419891008 "Record artifact"

--- a/input/fsh/mhd.fsh
+++ b/input/fsh/mhd.fsh
@@ -314,144 +314,144 @@ ValueSet: VS_DocType_371531000
 Id: vs-doctype-371531000
 Title: "Targets for classCode 371531000 (Report of clinical encounter)"
 * ^status = #active
-* $sct#371530004 "Clinical consultation report"
-* $sct#371529009 "History and physical report"
-* $sct#371532007 "Progress report"
-* $sct#419891008 "Record artifact"
+* $sct#371530004
+* $sct#371529009
+* $sct#371532007
+* $sct#419891008
 
 // Group 2 — 721927009 Referral note
 ValueSet: VS_DocType_721927009
 Id: vs-doctype-721927009
 Title: "Targets for classCode 721927009 (Referral note)"
 * ^status = #active
-* $sct#419891008 "Record artifact"
+* $sct#419891008
 
 // Group 3 — 721963009 Order
 ValueSet: VS_DocType_721963009
 Id: vs-doctype-721963009
 Title: "Targets for classCode 721963009 (Order)"
 * ^status = #active
-* $sct#721965002 "Laboratory order"
-* $sct#721966001 "Pathology order"
-* $sct#2161000195103 "Imaging order"
-* $sct#419891008 "Record artifact"
+* $sct#721965002
+* $sct#721966001
+* $sct#2161000195103
+* $sct#419891008
 
 // Group 4 — 422735006 Summary clinical document
 ValueSet: VS_DocType_422735006
 Id: vs-doctype-422735006
 Title: "Targets for classCode 422735006 (Summary clinical document)"
 * ^status = #active
-* $sct#373942005 "Discharge summary"
-* $sct#371535009 "Transfer summary report"
-* $sct#721912009 "Medication summary document"
-* $sct#736378000 "Medication management plan"
-* $sct#419891008 "Record artifact"
+* $sct#373942005
+* $sct#371535009
+* $sct#721912009
+* $sct#736378000
+* $sct#419891008
 
 // Group 5 — 371525003 Clinical procedure report
 ValueSet: VS_DocType_371525003
 Id: vs-doctype-371525003
 Title: "Targets for classCode 371525003 (Clinical procedure report)"
 * ^status = #active
-* $sct#371526002 "Operative report"
-* $sct#4241000179101 "Laboratory report"
-* $sct#371528001 "Pathology report"
-* $sct#4201000179104 "Imaging report"
-* $sct#900000000000471006 "Image reference"
-* $sct#787148009 "Digital representation of specimen"
-* $sct#419891008 "Record artifact"
+* $sct#371526002
+* $sct#4241000179101
+* $sct#371528001
+* $sct#4201000179104
+* $sct#900000000000471006
+* $sct#787148009
+* $sct#419891008
 
 // Group 6 — 734163000 Care plan
 ValueSet: VS_DocType_734163000
 Id: vs-doctype-734163000
 Title: "Targets for classCode 734163000 (Care plan)"
 * ^status = #active
-* $sct#737427001 "Clinical management plan"
-* $sct#773130005 "Nursing care plan"
-* $sct#736055001 "Rehabilitation care plan"
-* $sct#761931002 "Medication treatment plan report"
-* $sct#419891008 "Record artifact"
+* $sct#737427001
+* $sct#773130005
+* $sct#736055001
+* $sct#761931002
+* $sct#419891008
 
 // Group 7 — 440545006 Prescription record
 ValueSet: VS_DocType_440545006
 Id: vs-doctype-440545006
 Title: "Targets for classCode 440545006 (Prescription record)"
 * ^status = #active
-* $sct#761938008 "Medicinal prescription record"
-* $sct#765492005 "Non-drug prescription record"
-* $sct#419891008 "Record artifact"
+* $sct#761938008
+* $sct#765492005
+* $sct#419891008
 
 // Group 8 — 184216000 Patient record type
 ValueSet: VS_DocType_184216000
 Id: vs-doctype-184216000
 Title: "Targets for classCode 184216000 (Patient record type)"
 * ^status = #active
-* $sct#722446000 "Allergy record"
-* $sct#41000179103 "Immunization record"
-* $sct#419891008 "Record artifact"
+* $sct#722446000
+* $sct#41000179103
+* $sct#419891008
 
 // Group 9 — 371537001 Consent report
 ValueSet: VS_DocType_371537001
 Id: vs-doctype-371537001
 Title: "Targets for classCode 371537001 (Consent report)"
 * ^status = #active
-* $sct#419891008 "Record artifact"
+* $sct#419891008
 
 // Group 10 — 371538006 Advance directive report
 ValueSet: VS_DocType_371538006
 Id: vs-doctype-371538006
 Title: "Targets for classCode 371538006 (Advance directive report)"
 * ^status = #active
-* $sct#419891008 "Record artifact"
+* $sct#419891008
 
 // Group 11 — 722160009 Audit trail report
 ValueSet: VS_DocType_722160009
 Id: vs-doctype-722160009
 Title: "Targets for classCode 722160009 (Audit trail report)"
 * ^status = #active
-* $sct#419891008 "Record artifact"
+* $sct#419891008
 
 // Group 12 — 722216001 Emergency medical identification record
 ValueSet: VS_DocType_722216001
 Id: vs-doctype-722216001
 Title: "Targets for classCode 722216001 (Emergency medical identification record)"
 * ^status = #active
-* $sct#419891008 "Record artifact"
+* $sct#419891008
 
 // Group 13 — 772790007 Organ donor card
 ValueSet: VS_DocType_772790007
 Id: vs-doctype-772790007
 Title: "Targets for classCode 772790007 (Organ donor card)"
 * ^status = #active
-* $sct#419891008 "Record artifact"
+* $sct#419891008
 
 // Group 14 — 405624007 Administrative documentation
 ValueSet: VS_DocType_405624007
 Id: vs-doctype-405624007
 Title: "Targets for classCode 405624007 (Administrative documentation)"
 * ^status = #active
-* $sct#772786005 "Medical certificate"
-* $sct#419891008 "Record artifact"
+* $sct#772786005
+* $sct#419891008
 
 // Group 15/16 — 417319006 Record of health event
 ValueSet: VS_DocType_417319006
 Id: vs-doctype-417319006
 Title: "Targets for classCode 417319006 (Record of health event)"
 * ^status = #active
-* $sct#445300006 "Emergency department record"
-* $sct#445418005 "Professional allied to medicine clinical report"
-* $sct#82291000195104 "Medication dispense document"
-* $sct#419891008 "Record artifact"
+* $sct#445300006
+* $sct#445418005
+* $sct#82291000195104
+* $sct#419891008
 
 // Group 17 — 2171000195109 Obstetrical record
 ValueSet: VS_DocType_2171000195109
 Id: vs-doctype-2171000195109
 Title: "Targets for classCode 2171000195109 (Obstetrical record)"
 * ^status = #active
-* $sct#419891008 "Record artifact"
+* $sct#419891008
 
 // Group 18 — 419891008 Record artifact (self-map)
 ValueSet: VS_DocType_419891008
 Id: vs-doctype-419891008
 Title: "Targets for classCode 419891008 (Record artifact)"
 * ^status = #active
-* $sct#419891008 "Record artifact"
+* $sct#419891008

--- a/input/fsh/mhd.fsh
+++ b/input/fsh/mhd.fsh
@@ -148,27 +148,24 @@ be the the one to use in ITI-68 transactions to retrieve the document content."
 * context.related[StudyInstanceUID].identifier only DicomStudyInstanceUidIdentifier
 * context.related[StudyInstanceUID].identifier ^short = "Requirements on XDS-I.b (Swiss context): When a Imaging Document Source provides a document to the Document Repository, it must provide the StudyInstanceUID, found in the to be registered KOS object, in the referenceIdList (urn:ihe:iti:xds:2013:referenceIdList) attribute of the documentEntry metadata."
 
-
-* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, category, DocumentReference.type, 371531000, VS_DocType_371531000, extensible)
-* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, category, DocumentReference.type, 721927009, VS_DocType_721927009, extensible)
-* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, category, DocumentReference.type, 721963009, VS_DocType_721963009, extensible)
-* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, category, DocumentReference.type, 422735006, VS_DocType_422735006, extensible)
-* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, category, DocumentReference.type, 371525003, VS_DocType_371525003, extensible)
-* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, category, DocumentReference.type, 734163000, VS_DocType_734163000, extensible)
-* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, category, DocumentReference.type, 440545006, VS_DocType_440545006, extensible)
-* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, category, DocumentReference.type, 184216000, VS_DocType_184216000, extensible)
-* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, category, DocumentReference.type, 371537001, VS_DocType_371537001, extensible)
-* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, category, DocumentReference.type, 371538006, VS_DocType_371538006, extensible)
-* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, category, DocumentReference.type, 722160009, VS_DocType_722160009, extensible)
-* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, category, DocumentReference.type, 722216001, VS_DocType_722216001, extensible)
-* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, category, DocumentReference.type, 772790007, VS_DocType_772790007, extensible)
-* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, category, DocumentReference.type, 405624007, VS_DocType_405624007, extensible)
-* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, category, DocumentReference.type, 417319006, VS_DocType_417319006, extensible)
-* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, category, DocumentReference.type, 2171000195109, VS_DocType_2171000195109, extensible)
-* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, category, DocumentReference.type, 419891008, VS_DocType_419891008, extensible)
-
-
-
+//Tying type based on category
+* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, type, DocumentReference.category, 371531000, VS_DocType_371531000, required)
+* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, type, DocumentReference.category, 721927009, VS_DocType_721927009, required)
+* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, type, DocumentReference.category, 721963009, VS_DocType_721963009, required)
+* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, type, DocumentReference.category, 422735006, VS_DocType_422735006, required)
+* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, type, DocumentReference.category, 371525003, VS_DocType_371525003, required)
+* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, type, DocumentReference.category, 734163000, VS_DocType_734163000, required)
+* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, type, DocumentReference.category, 440545006, VS_DocType_440545006, required)
+* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, type, DocumentReference.category, 184216000, VS_DocType_184216000, required)
+* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, type, DocumentReference.category, 371537001, VS_DocType_371537001, required)
+* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, type, DocumentReference.category, 371538006, VS_DocType_371538006, required)
+* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, type, DocumentReference.category, 722160009, VS_DocType_722160009, required)
+* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, type, DocumentReference.category, 722216001, VS_DocType_722216001, required)
+* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, type, DocumentReference.category, 772790007, VS_DocType_772790007, required)
+* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, type, DocumentReference.category, 405624007, VS_DocType_405624007, required)
+* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, type, DocumentReference.category, 417319006, VS_DocType_417319006, required)
+* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, type, DocumentReference.category, 2171000195109, VS_DocType_2171000195109, required)
+* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, type, DocumentReference.category, 419891008, VS_DocType_419891008, required)
 
 Invariant: ch-mhd
 Description: "The DocumentReference needs to conform to IHE.MHD.Comprehensive.DocumentReference"
@@ -301,13 +298,12 @@ RuleSet: AdditionalBinding(profile, elementPath, usagePath, usageCategory, value
 * {elementPath} ^binding.extension[=].extension[0].url = "purpose"
 * {elementPath} ^binding.extension[=].extension[=].valueCode = #{binding}
 * {elementPath} ^binding.extension[=].extension[+].url = "valueSet"
-* {elementPath} ^binding.extension[=].extension[=].valueCanonical = {valueSet}
+* {elementPath} ^binding.extension[=].extension[=].valueCanonical = Canonical({valueSet})
 * {elementPath} ^binding.extension[=].extension[+].url = "usage"
 * {elementPath} ^binding.extension[=].extension[=].valueUsageContext.code.system = Canonical({profile})
 * {elementPath} ^binding.extension[=].extension[=].valueUsageContext.code.code = #{usagePath}
 * {elementPath} ^binding.extension[=].extension[=].valueUsageContext.valueCodeableConcept = $sct#{usageCategory} // This is not official display. Need to support display? "{profile} {usageCategory} ValueSet"
 * {elementPath} ^binding.extension[=].extension[=].valueUsageContext.valueCodeableConcept.text = "{usageCategory}"
-
 
 // Group 1 — 371531000 Report of clinical encounter
 ValueSet: VS_DocType_371531000

--- a/input/fsh/mhd.fsh
+++ b/input/fsh/mhd.fsh
@@ -149,23 +149,23 @@ be the the one to use in ITI-68 transactions to retrieve the document content."
 * context.related[StudyInstanceUID].identifier ^short = "Requirements on XDS-I.b (Swiss context): When a Imaging Document Source provides a document to the Document Repository, it must provide the StudyInstanceUID, found in the to be registered KOS object, in the referenceIdList (urn:ihe:iti:xds:2013:referenceIdList) attribute of the documentEntry metadata."
 
 //Tying type based on category
-* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, type, DocumentReference.category, 371531000, VS_DocType_371531000, required)
-* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, type, DocumentReference.category, 721927009, VS_DocType_721927009, required)
-* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, type, DocumentReference.category, 721963009, VS_DocType_721963009, required)
-* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, type, DocumentReference.category, 422735006, VS_DocType_422735006, required)
-* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, type, DocumentReference.category, 371525003, VS_DocType_371525003, required)
-* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, type, DocumentReference.category, 734163000, VS_DocType_734163000, required)
-* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, type, DocumentReference.category, 440545006, VS_DocType_440545006, required)
-* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, type, DocumentReference.category, 184216000, VS_DocType_184216000, required)
-* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, type, DocumentReference.category, 371537001, VS_DocType_371537001, required)
-* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, type, DocumentReference.category, 371538006, VS_DocType_371538006, required)
-* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, type, DocumentReference.category, 722160009, VS_DocType_722160009, required)
-* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, type, DocumentReference.category, 722216001, VS_DocType_722216001, required)
-* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, type, DocumentReference.category, 772790007, VS_DocType_772790007, required)
-* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, type, DocumentReference.category, 405624007, VS_DocType_405624007, required)
-* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, type, DocumentReference.category, 417319006, VS_DocType_417319006, required)
-* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, type, DocumentReference.category, 2171000195109, VS_DocType_2171000195109, required)
-* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, type, DocumentReference.category, 419891008, VS_DocType_419891008, required)
+* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, type, DocumentReference.category, 371531000, VS_DocCategory_371531000, required)
+* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, type, DocumentReference.category, 721927009, VS_DocCategory_721927009, required)
+* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, type, DocumentReference.category, 721963009, VS_DocCategory_721963009, required)
+* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, type, DocumentReference.category, 422735006, VS_DocCategory_422735006, required)
+* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, type, DocumentReference.category, 371525003, VS_DocCategory_371525003, required)
+* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, type, DocumentReference.category, 734163000, VS_DocCategory_734163000, required)
+* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, type, DocumentReference.category, 440545006, VS_DocCategory_440545006, required)
+* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, type, DocumentReference.category, 184216000, VS_DocCategory_184216000, required)
+* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, type, DocumentReference.category, 371537001, VS_DocCategory_371537001, required)
+* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, type, DocumentReference.category, 371538006, VS_DocCategory_371538006, required)
+* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, type, DocumentReference.category, 722160009, VS_DocCategory_722160009, required)
+* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, type, DocumentReference.category, 722216001, VS_DocCategory_722216001, required)
+* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, type, DocumentReference.category, 772790007, VS_DocCategory_772790007, required)
+* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, type, DocumentReference.category, 405624007, VS_DocCategory_405624007, required)
+* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, type, DocumentReference.category, 417319006, VS_DocCategory_417319006, required)
+* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, type, DocumentReference.category, 2171000195109, VS_DocCategory_2171000195109, required)
+* insert AdditionalBinding(CHMhdDocumentReferenceComprehensive, type, DocumentReference.category, 419891008, VS_DocCategory_419891008, required)
 
 Invariant: ch-mhd
 Description: "The DocumentReference needs to conform to IHE.MHD.Comprehensive.DocumentReference"
@@ -296,7 +296,7 @@ Description: "CH MHD SubmissionSet Comprehensive"
 RuleSet: AdditionalBinding(profile, elementPath, usagePath, usageCategory, valueSet, binding)
 * {elementPath} ^binding.extension[+].url = $add-binding
 * {elementPath} ^binding.extension[=].extension[0].url = "key"
-* {elementPath} ^binding.extension[=].extension[=].valueId = category-to-type
+* {elementPath} ^binding.extension[=].extension[=].valueId = type-for-category
 * {elementPath} ^binding.extension[=].extension[+].url = "purpose"
 * {elementPath} ^binding.extension[=].extension[=].valueCode = #{binding}
 * {elementPath} ^binding.extension[=].extension[+].url = "valueSet"
@@ -307,9 +307,10 @@ RuleSet: AdditionalBinding(profile, elementPath, usagePath, usageCategory, value
 * {elementPath} ^binding.extension[=].extension[=].valueUsageContext.valueCodeableConcept = $sct#{usageCategory}
 
 // Group 1 — 371531000 Report of clinical encounter
-ValueSet: VS_DocType_371531000
-Id: vs-doctype-371531000
-Title: "Targets for classCode 371531000 (Report of clinical encounter)"
+ValueSet: VS_DocCategory_371531000
+Id: doccategory-371531000
+Title: "DocType for DocCategory 371531000"
+Description: "Target typeCodes for classCode SCT 371531000 (Report of clinical encounter)"
 * ^status = #active
 * $sct#371530004
 * $sct#371529009
@@ -317,16 +318,18 @@ Title: "Targets for classCode 371531000 (Report of clinical encounter)"
 * $sct#419891008
 
 // Group 2 — 721927009 Referral note
-ValueSet: VS_DocType_721927009
-Id: vs-doctype-721927009
-Title: "Targets for classCode 721927009 (Referral note)"
+ValueSet: VS_DocCategory_721927009
+Id: doccategory-721927009
+Title: "DocType for DocCategory 721927009"
+Description: "Target typeCodes for classCode SCT 721927009 (Referral note)"
 * ^status = #active
 * $sct#419891008
 
 // Group 3 — 721963009 Order
-ValueSet: VS_DocType_721963009
-Id: vs-doctype-721963009
-Title: "Targets for classCode 721963009 (Order)"
+ValueSet: VS_DocCategory_721963009
+Id: doccategory-721963009
+Title: "DocType for DocCategory 721963009"
+Description: "Target typeCodes for classCode SCT 721963009 (Order)"
 * ^status = #active
 * $sct#721965002
 * $sct#721966001
@@ -334,9 +337,10 @@ Title: "Targets for classCode 721963009 (Order)"
 * $sct#419891008
 
 // Group 4 — 422735006 Summary clinical document
-ValueSet: VS_DocType_422735006
-Id: vs-doctype-422735006
-Title: "Targets for classCode 422735006 (Summary clinical document)"
+ValueSet: VS_DocCategory_422735006
+Id: doccategory-422735006
+Title: "DocType for DocCategory 422735006"
+Description: "Target typeCodes for classCode SCT 422735006 (Summary clinical document)"
 * ^status = #active
 * $sct#373942005
 * $sct#371535009
@@ -345,9 +349,10 @@ Title: "Targets for classCode 422735006 (Summary clinical document)"
 * $sct#419891008
 
 // Group 5 — 371525003 Clinical procedure report
-ValueSet: VS_DocType_371525003
-Id: vs-doctype-371525003
-Title: "Targets for classCode 371525003 (Clinical procedure report)"
+ValueSet: VS_DocCategory_371525003
+Id: doccategory-371525003
+Title: "DocType for DocCategory 371525003"
+Description: "Target typeCodes for classCode SCT 371525003 (Clinical procedure report)"
 * ^status = #active
 * $sct#371526002
 * $sct#4241000179101
@@ -358,9 +363,10 @@ Title: "Targets for classCode 371525003 (Clinical procedure report)"
 * $sct#419891008
 
 // Group 6 — 734163000 Care plan
-ValueSet: VS_DocType_734163000
-Id: vs-doctype-734163000
-Title: "Targets for classCode 734163000 (Care plan)"
+ValueSet: VS_DocCategory_734163000
+Id: doccategory-734163000
+Title: "DocType for DocCategory 734163000"
+Description: "Target typeCodes for classCode SCT 734163000 (Care plan)"
 * ^status = #active
 * $sct#737427001
 * $sct#773130005
@@ -369,70 +375,79 @@ Title: "Targets for classCode 734163000 (Care plan)"
 * $sct#419891008
 
 // Group 7 — 440545006 Prescription record
-ValueSet: VS_DocType_440545006
-Id: vs-doctype-440545006
-Title: "Targets for classCode 440545006 (Prescription record)"
+ValueSet: VS_DocCategory_440545006
+Id: doccategory-440545006
+Title: "DocType for DocCategory 440545006"
+Description: "Target typeCodes for classCode SCT 440545006 (Prescription record)"
 * ^status = #active
 * $sct#761938008
 * $sct#765492005
 * $sct#419891008
 
 // Group 8 — 184216000 Patient record type
-ValueSet: VS_DocType_184216000
-Id: vs-doctype-184216000
-Title: "Targets for classCode 184216000 (Patient record type)"
+ValueSet: VS_DocCategory_184216000
+Id: doccategory-184216000
+Title: "DocType for DocCategory 184216000"
+Description: "Target typeCodes for classCode SCT 184216000 (Patient record type)"
 * ^status = #active
 * $sct#722446000
 * $sct#41000179103
 * $sct#419891008
 
 // Group 9 — 371537001 Consent report
-ValueSet: VS_DocType_371537001
-Id: vs-doctype-371537001
-Title: "Targets for classCode 371537001 (Consent report)"
+ValueSet: VS_DocCategory_371537001
+Id: doccategory-371537001
+Title: "DocType for DocCategory 371537001"
+Description: "Target typeCodes for classCode SCT 371537001 (Consent report)"
 * ^status = #active
 * $sct#419891008
 
 // Group 10 — 371538006 Advance directive report
-ValueSet: VS_DocType_371538006
-Id: vs-doctype-371538006
-Title: "Targets for classCode 371538006 (Advance directive report)"
+ValueSet: VS_DocCategory_371538006
+Id: doccategory-371538006
+Title: "DocType for DocCategory 371538006"
+Description: "Target typeCodes for classCode SCT 371538006 (Advance directive report)"
 * ^status = #active
 * $sct#419891008
 
 // Group 11 — 722160009 Audit trail report
-ValueSet: VS_DocType_722160009
-Id: vs-doctype-722160009
-Title: "Targets for classCode 722160009 (Audit trail report)"
+ValueSet: VS_DocCategory_722160009
+Id: doccategory-722160009
+Title: "DocType for DocCategory 722160009"
+Description: "Target typeCodes for classCode SCT 722160009 (Audit trail report)"
 * ^status = #active
 * $sct#419891008
 
 // Group 12 — 722216001 Emergency medical identification record
-ValueSet: VS_DocType_722216001
-Id: vs-doctype-722216001
-Title: "Targets for classCode 722216001 (Emergency medical identification record)"
+ValueSet: VS_DocCategory_722216001
+Id: doccategory-722216001
+Title: "DocType for DocCategory 722216001"
+Description: "Target typeCodes for classCode SCT 722216001 (Emergency medical identification record)"
 * ^status = #active
 * $sct#419891008
 
 // Group 13 — 772790007 Organ donor card
-ValueSet: VS_DocType_772790007
-Id: vs-doctype-772790007
-Title: "Targets for classCode 772790007 (Organ donor card)"
+ValueSet: VS_DocCategory_772790007
+Id: doccategory-772790007
+Title: "DocType for DocCategory 772790007"
+Description: "Target typeCodes for classCode SCT 772790007 (Organ donor card)"
 * ^status = #active
 * $sct#419891008
 
 // Group 14 — 405624007 Administrative documentation
-ValueSet: VS_DocType_405624007
-Id: vs-doctype-405624007
-Title: "Targets for classCode 405624007 (Administrative documentation)"
+ValueSet: VS_DocCategory_405624007
+Id: doccategory-405624007
+Title: "DocType for DocCategory 405624007"
+Description: "Target typeCodes for classCode SCT 405624007 (Administrative documentation)"
 * ^status = #active
 * $sct#772786005
 * $sct#419891008
 
 // Group 15/16 — 417319006 Record of health event
-ValueSet: VS_DocType_417319006
-Id: vs-doctype-417319006
-Title: "Targets for classCode 417319006 (Record of health event)"
+ValueSet: VS_DocCategory_417319006
+Id: doccategory-417319006
+Title: "DocType for DocCategory 417319006"
+Description: "Target typeCodes for classCode SCT 417319006 (Record of health event)"
 * ^status = #active
 * $sct#445300006
 * $sct#445418005
@@ -440,15 +455,17 @@ Title: "Targets for classCode 417319006 (Record of health event)"
 * $sct#419891008
 
 // Group 17 — 2171000195109 Obstetrical record
-ValueSet: VS_DocType_2171000195109
-Id: vs-doctype-2171000195109
-Title: "Targets for classCode 2171000195109 (Obstetrical record)"
+ValueSet: VS_DocCategory_2171000195109
+Id: doccategory-2171000195109
+Title: "DocType for DocCategory 2171000195109"
+Description: "Target typeCodes for classCode SCT 2171000195109 (Obstetrical record)"
 * ^status = #active
 * $sct#419891008
 
 // Group 18 — 419891008 Record artifact (self-map)
-ValueSet: VS_DocType_419891008
-Id: vs-doctype-419891008
-Title: "Targets for classCode 419891008 (Record artifact)"
+ValueSet: VS_DocCategory_419891008
+Id: doccategory-419891008
+Title: "DocType for DocCategory 419891008"
+Description: "Target typeCodes for classCode SCT 419891008 (Record artifact)"
 * ^status = #active
 * $sct#419891008

--- a/input/ignoreWarnings.txt
+++ b/input/ignoreWarnings.txt
@@ -11,7 +11,7 @@ A definition for CodeSystem 'urn:ihe:iti:xca:2010' could not be found, so the co
 # Inactive codes used in value sets
 The code '264358009' is valid but is not active
 
-# Non-conformance to 'preferred' value sets / it has no suitable code
+# Non-conformance to 'preferred'/'extensible' value sets / it has no suitable code
 None of the codings provided are in the value set 'Practice Setting Code Value Set' (http://hl7.org/fhir/ValueSet/c80-practice-codes|%
 None of the codings provided are in the value set 'ParticipationRoleType' (http://hl7.org/fhir/ValueSet/participation-role-type|%
 None of the codings provided are in the value set 'PurposeOfUse' (http://terminology.hl7.org/ValueSet/v3-PurposeOfUse|%
@@ -25,6 +25,7 @@ The Coding provided (urn:oid:2.16.756.5.30.1.127.3.10.7#%
 The Coding provided (http://terminology.hl7.org/CodeSystem/object-role#%
 The Coding provided (urn:oid:2.16.756.5.30.1.127.3.10.6#%
 The Coding provided (urn:oid:2.16.756.5.30.1.127.3.10.14#%
+The Coding provided (http://fhir.ch/ig/ch-epr-fhir/StructureDefinition/ch-mhd-documentreference-comprehensive#DocumentReference.category) was not found in the value set 'UsageContextType' (http://hl7.org/fhir/ValueSet/usage-context-type|%
 
 # IG Publisher limitations
 No types could be determined from the search string, so the types can't be checked

--- a/input/pagecontent/changelog.md
+++ b/input/pagecontent/changelog.md
@@ -1,3 +1,9 @@
+### DSTU5 Informative Ballot Release 2025-12
+
+#### Resolved Issues
+* Additional bindings on DocumentReference [#354](https://github.com/ehealthsuisse/ch-epr-fhir/issues/354)
+
+
 ### DSTU5 Informative Ballot 2025 
 
 #### Open Issues


### PR DESCRIPTION
The origin PR https://github.com/ehealthsuisse/ch-epr-fhir/pull/355 to fix issue https://github.com/ehealthsuisse/ch-epr-fhir/issues/354 came from @jkiddo, thanks for providing! 
This PR incorporates those changes, and I've made a few adjustments (resolve warnings, add descriptions and try to clarify wording).

### Feature provided in this PR
Usage of the [additional binding extension](http://hl7.org/fhir/tools/StructureDefinition/additional-binding) in the [CH MHD DocumentReference Comprehensive](https://fhir.ch/ig/ch-epr-fhir/StructureDefinition-ch-mhd-documentreference-comprehensive.html) profile on the element `type`. It allows you to validate the mapping of the **DocumentEntry.classCodes** (`category`) to the **DocumentEntry.typeCodes** (`type`) as we defined it in this [ConceptMap](https://fhir.ch/ig/ch-term/ConceptMap-DocumentEntryClassCodeToDocumentEntryTypeCode.html).

If `type` and `category` appear in a wrong combination, the validation output is as following:
error: `None of the codings provided are in the value set 'Targets for classCode 721963009 (Order)' (http://fhir.ch/ig/ch-epr-fhir/ValueSet/vs-doctype-721963009|5.0.0-ci-build) specified in an additional binding which applies because DocumentReference.category = 721963009, and a coding from this value set is required) (codes = http://snomed.info/sct#721912009)`

To include this in the profile, follwing steps were necessary:
- Definition of 17 ValueSets, for each classCode (`category`) one ValueSet
- These ValueSets include the concepts for the according typeCodes (`type`)
- Add these 17 ValueSet bindings (according to a specific `category` code) to the type element
<img width="1343" height="203" alt="image" src="https://github.com/user-attachments/assets/055eccb0-8cfd-44a8-bf06-a452e609de89" />

### Proposal for next steps to integrate it in the Swiss environment
- Include those 17 ValueSets in CH Term (as the VS/CM for typeCode/classCode are) (to avoid version conflicts by having it in two places).
- The origin source for them is Art-Decor (the ConceptMap is generated with an Art-Decor export).
- The ConceptMap cannot use these ValueSets as the [R4 spec](https://hl7.org/fhir/R4/conceptmap.html) requires concepts on the group level. See also [comment below](https://github.com/ehealthsuisse/ch-epr-fhir/pull/358#issuecomment-3209883015).
- To avoid manually work in the future and consistency issues, it would be recommended to write another script (next to that for the CM) to generate these VS from an Art-Decor export.
- There could be a potential problem, as we would have the VS in CH Term and there be flexibel with updates, we may do have a different publication timeline for CH EPR FHIR and in the profile, the category codes are "hard coded" and wouldn't adapt to changes in CH Term automatically.