### PR TITLE
Update iti-71.md

### DIFF
--- a/input/pagecontent/iti-71.md
+++ b/input/pagecontent/iti-71.md
@@ -763,30 +763,11 @@ user:
 
 - user_id: subject identifier according to Annex 5 E1, section 1.6.4.3.4.2 Message Semantics.
 
-<table class="table table-bordered">
-  <thead>
-    <tr>
-      <th>JWT Claim (Extension)</th>
-      <th>Optionality (Basic/ Extended)</th>
-      <th>XUA Attribute EPR</th>
-      <th>Remark</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>user_id</td>
-      <td>O/R</td>
-      <td>&lt;NameID&gt; child element of the &lt;Subject&gt;</td>
-      <td>&nbsp;</td>
-    </tr>
-    <tr>
-      <td>user_id_qualifier</td>
-      <td>O/R</td>
-      <td>Name qualifier attribute of &lt;NameID&gt;</td>
-      <td>&nbsp;</td>
-    </tr>
-  </tbody>
-</table>
+| JWT Claim (Extension) | Optionality (Basic/ Extended) | XUA Attribute EPR                                   | Remark |
+|-----------------------|-------------------------------|-----------------------------------------------------|--------|
+| user_id               | O/R                           | &lt;NameID&gt; child element of the &lt;Subject&gt; |        |
+| user_id_qualifier     | O/R                           | Name qualifier attribute of &lt;NameID&gt;          |        |
+{:class="table table-bordered"}
 
 <figcaption>Table: Attributes of the IUA Get Access Token response in the JWT extension ch_epr.</figcaption>
 
@@ -801,32 +782,13 @@ of groups a subject is member of:
 The ch_group extension claims shall be wrapped in an "extensions" object with key "ch_group" and a JSON array containing
 the JSON objects with properties name and id. The id SHALL be an OID in the format of a URN.
 
-<table class="table table-bordered">
-  <thead>
-    <tr>
-      <th>ch_group array element</th>
-      <th>Optionality (Basic/ Extended)</th>
-      <th>XUA Attribute EPR</th>
-      <th>Remark</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>name</td>
-      <td>O/R</td>
-      <td>urn:oasis:names:tc:xspa:1.0:subject:organization</td>
-      <td>An array of groups with properties name and id.</td>
-    </tr>
-    <tr>
-      <td>id</td>
-      <td>O/R</td>
-      <td>urn:oasis:names:tc:xspa:1.0:subject:organization-id</td>
-      <td>An array of group names and group ids.</td>
-    </tr>
-  </tbody>
-</table>
+| ch_group array element | Optionality (Basic/ Extended) | XUA Attribute EPR                                   | Remark                                          |
+|------------------------|-------------------------------|-----------------------------------------------------|-------------------------------------------------|
+| name                   | O/R                           | urn:oasis:names:tc:xspa:1.0:subject:organization    | An array of groups with properties name and id. |
+| id                     | O/R                           | urn:oasis:names:tc:xspa:1.0:subject:organization-id | An array of group names and group ids.          |
+{:class="table table-bordered"}
 
-<figcaption class="table table-bordered">Table: Attributes of the IUA Get Access Token response in the JWT extension ch_group.</figcaption>
+<figcaption>Table: Attributes of the IUA Get Access Token response in the JWT extension ch_group.</figcaption> 
 
 ###### The JWT ch_delegation extension
 
@@ -839,32 +801,13 @@ The ch_delegation extension claims shall be wrapped in an "extensions" object wi
 object containing the claims. The claim content for the JWT CH:EPR extensions shall correspond to the content defined 
 in the XUA specification (see 1.6.4.2 Get X-User Assertion, A5E1).
 
-<table class="table table-bordered">
-  <thead>
-    <tr>
-      <th>JWT Claim (Extension)</th>
-      <th>Optionality (Basic/ Extended)</th>
-      <th>XUA Attribute EPR</th>
-      <th>Remark</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>principal</td>
-      <td>O/R</td>
-      <td>urn:e-health-suisse:principal-name</td>
-      <td>Name of the healthcare professional an assistant is acting on behalf of.</td>
-    </tr>
-    <tr>
-      <td>principal_id</td>
-      <td>O/R</td>
-      <td>urn:e-health-suisse:principal-id</td>
-      <td>GLN of the healthcare professional an assistant is acting on behalf of.</td>
-    </tr>
-  </tbody>
-</table>
+| JWT Claim (Extension) | Optionality (Basic/ Extended) | XUA Attribute EPR                  | Remark                                                                   |
+|-----------------------|-------------------------------|------------------------------------|--------------------------------------------------------------------------|
+| principal             | O/R                           | urn:e-health-suisse:principal-name | Name of the healthcare professional an assistant is acting on behalf of. |
+| principal_id          | O/R                           | urn:e-health-suisse:principal-id   | GLN of the healthcare professional an assistant is acting on behalf of.  |
+{:class="table table-bordered"}
 
-<figcaption class="table table-bordered">Table: Attributes of the IUA Get Access Token response in the JWT extension ch_delegation.</figcaption>
+<figcaption>Table: Attributes of the IUA Get Access Token response in the JWT extension ch_delegation.</figcaption>
 
 ##### Expected Actions
 


### PR DESCRIPTION

Done: 
- corrected table layout 
- fixed copy paste error in table caption

Note:
The subject_name and subject_id elements of the hl7-b2b extension define the name and the unique identifier of the requestor. In contrast, the ch_delegation extension defines the name and id of the requestors supervisor, when the requestor is an assistant. Therefore we cannot refer to the hl7-b2b extension 