### PR TITLE
Clarify designationType must be 'Procedure' for Swiss EPR

### DIFF
--- a/input/fsh/mhd.fsh
+++ b/input/fsh/mhd.fsh
@@ -247,6 +247,7 @@ Description: "CH MHD SubmissionSet Comprehensive"
 * extension 2..
 * extension contains $ch-ext-author-authorrole named authorAuthorRole 0..1 MS
 * extension[designationType].value[x] from $SubmissionSet.contentTypeCode (required)
+* extension[designationType].value[x] ^short = "Fixed code 'Procedure' by the Swiss EPR"
 * extension[designationType] ^sliceName = "designationType"
 * extension[designationType] ^mustSupport = true
 * extension[sourceId] ^sliceName = "sourceId"

--- a/input/pagecontent/changelog.md
+++ b/input/pagecontent/changelog.md
@@ -2,6 +2,7 @@
 
 #### Resolved Issues
 * Unknown code '26' in the CodeSystem 'http://terminology.hl7.org/CodeSystem/object-role' version '1.0.0': waiting to be added, see [#190](https://github.com/ehealthsuisse/ch-epr-fhir/issues/190)
+* MHD: Clarify that designationType must be fixed to 'Procedure' for Swiss EPR in CHMhdSubmissionSetComprehensive [#385](https://github.com/ehealthsuisse/ch-epr-fhir/issues/385)
 * Sequence Diagrams - mention mTLS for ITI-65, 67, 68 [#357](https://github.com/ehealthsuisse/ch-epr-fhir/issues/357)
 * On ITI-81 transaction description in Volume 2 [#322](https://github.com/ehealthsuisse/ch-epr-fhir/issues/322)
 * Bundle profile for updating multiple document references in CH:MHD-1 [#361](https://github.com/ehealthsuisse/ch-epr-fhir/issues/361) and [#351](https://github.com/ehealthsuisse/ch-epr-fhir/issues/351)


### PR DESCRIPTION
## Summary
- Added clarification text to the CHMhdSubmissionSetComprehensive profile in [input/fsh/mhd.fsh:250](input/fsh/mhd.fsh#L250)
- Added `^short = "Fixed code 'Procedure' by the Swiss EPR"` to the `extension[designationType].value[x]` element
- Updated [changelog.md](input/pagecontent/changelog.md) to reflect this change

Fixes #385