### PR TITLE
ATC: add Tracecontext values to ATC examples

### DIFF
--- a/input/examples/auditevent/atc-doc-create-rep-pat.xml
+++ b/input/examples/auditevent/atc-doc-create-rep-pat.xml
@@ -122,4 +122,23 @@
          <!-- base64 title Austrittsbericht von Julia Helfe-Gern  -->
       </detail>
    </entity>
+    <!--  TraceContext  -->
+    <entity>
+        <what>
+            <identifier>
+                <value value="00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-00"/>
+            </identifier>
+        </what>
+        <type>
+            <system
+                    value="http://terminology.hl7.org/CodeSystem/audit-entity-type"/>
+            <code value="4"/>
+            <display value="Other"/>
+        </type>
+        <role>
+            <system value="http://terminology.hl7.org/CodeSystem/object-role"/>
+            <code value="26"/>
+            <display value="Processing Element"/>
+        </role>
+    </entity>
 </AuditEvent>

--- a/input/examples/auditevent/atc-doc-read-ass-hpc.xml
+++ b/input/examples/auditevent/atc-doc-read-ass-hpc.xml
@@ -138,4 +138,23 @@
          <!-- base64 title Austrittsbericht  -->
       </detail>
    </entity>
+    <!--  TraceContext  -->
+    <entity>
+        <what>
+            <identifier>
+                <value value="00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-00"/>
+            </identifier>
+        </what>
+        <type>
+            <system
+                    value="http://terminology.hl7.org/CodeSystem/audit-entity-type"/>
+            <code value="4"/>
+            <display value="Other"/>
+        </type>
+        <role>
+            <system value="http://terminology.hl7.org/CodeSystem/object-role"/>
+            <code value="26"/>
+            <display value="Processing Element"/>
+        </role>
+    </entity>
 </AuditEvent>

--- a/input/examples/auditevent/atc-doc-search.xml
+++ b/input/examples/auditevent/atc-doc-search.xml
@@ -102,4 +102,23 @@
             <display value="Query"/>
         </role>
     </entity>
+    <!--  TraceContext  -->
+    <entity>
+        <what>
+            <identifier>
+                <value value="00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-00"/>
+            </identifier>
+        </what>
+        <type>
+            <system
+                    value="http://terminology.hl7.org/CodeSystem/audit-entity-type"/>
+            <code value="4"/>
+            <display value="Other"/>
+        </type>
+        <role>
+            <system value="http://terminology.hl7.org/CodeSystem/object-role"/>
+            <code value="26"/>
+            <display value="Processing Element"/>
+        </role>
+    </entity>
 </AuditEvent>

--- a/input/examples/auditevent/atc-hpd-group-entry-notify.xml
+++ b/input/examples/auditevent/atc-hpd-group-entry-notify.xml
@@ -92,4 +92,23 @@
         </role>
         <name value="Kardiologie Universitätsspital Musterstadt"/>
     </entity>
+    <!--  TraceContext  -->
+    <entity>
+        <what>
+            <identifier>
+                <value value="00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-00"/>
+            </identifier>
+        </what>
+        <type>
+            <system
+                    value="http://terminology.hl7.org/CodeSystem/audit-entity-type"/>
+            <code value="4"/>
+            <display value="Other"/>
+        </type>
+        <role>
+            <system value="http://terminology.hl7.org/CodeSystem/object-role"/>
+            <code value="26"/>
+            <display value="Processing Element"/>
+        </role>
+    </entity>
 </AuditEvent>

--- a/input/examples/auditevent/atc-log-read.xml
+++ b/input/examples/auditevent/atc-log-read.xml
@@ -59,4 +59,23 @@
          <display value="Patient"></display>
       </role>
    </entity>
+    <!--  TraceContext  -->
+    <entity>
+        <what>
+            <identifier>
+                <value value="00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-00"/>
+            </identifier>
+        </what>
+        <type>
+            <system
+                    value="http://terminology.hl7.org/CodeSystem/audit-entity-type"/>
+            <code value="4"/>
+            <display value="Other"/>
+        </type>
+        <role>
+            <system value="http://terminology.hl7.org/CodeSystem/object-role"/>
+            <code value="26"/>
+            <display value="Processing Element"/>
+        </role>
+    </entity>
 </AuditEvent>

--- a/input/examples/auditevent/atc-pol-create-acc-right.xml
+++ b/input/examples/auditevent/atc-pol-create-acc-right.xml
@@ -89,4 +89,23 @@
          <!-- base64 of 2020-12-31 -->
       </detail>
    </entity>
+    <!--  TraceContext  -->
+    <entity>
+        <what>
+            <identifier>
+                <value value="00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-00"/>
+            </identifier>
+        </what>
+        <type>
+            <system
+                    value="http://terminology.hl7.org/CodeSystem/audit-entity-type"/>
+            <code value="4"/>
+            <display value="Other"/>
+        </type>
+        <role>
+            <system value="http://terminology.hl7.org/CodeSystem/object-role"/>
+            <code value="26"/>
+            <display value="Processing Element"/>
+        </role>
+    </entity>
 </AuditEvent>

--- a/input/examples/auditevent/atc-pol-create-rep.xml
+++ b/input/examples/auditevent/atc-pol-create-rep.xml
@@ -73,4 +73,23 @@
       </role>
       <name value="Julia Helfe-Gern"></name>
    </entity>
+    <!--  TraceContext  -->
+    <entity>
+        <what>
+            <identifier>
+                <value value="00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-00"/>
+            </identifier>
+        </what>
+        <type>
+            <system
+                    value="http://terminology.hl7.org/CodeSystem/audit-entity-type"/>
+            <code value="4"/>
+            <display value="Other"/>
+        </type>
+        <role>
+            <system value="http://terminology.hl7.org/CodeSystem/object-role"/>
+            <code value="26"/>
+            <display value="Processing Element"/>
+        </role>
+    </entity>
 </AuditEvent>

--- a/input/pagecontent/changelog.md
+++ b/input/pagecontent/changelog.md
@@ -11,6 +11,7 @@
 * Update to Mobile Care Services Discovery (mCSD) to Release 4.0.0 [#346](https://github.com/ehealthsuisse/ch-epr-fhir/issues/346) and fix link [#352](https://github.com/ehealthsuisse/ch-epr-fhir/issues/352)
 * MHD: Remove authorOrg extension prohibition from CHMhdSubmissionSetComprehensive [#403](https://github.com/ehealthsuisse/ch-epr-fhir/issues/403)
 * Tracecontext: improve wording of the requirements [#393](https://github.com/ehealthsuisse/ch-epr-fhir/issues/393)
+* ATC: add Tracecontext values to ATC examples [#371](https://github.com/ehealthsuisse/ch-epr-fhir/issues/371)
 
 ### DSTU5 Informative Ballot 2025 
 


### PR DESCRIPTION
Fixes #371

Preview: https://build.fhir.org/ig/ehealthsuisse/ch-epr-fhir/branches/371-add-a-tracecontext-entity-to-atc-auditevent-examples/
QA: https://build.fhir.org/ig/ehealthsuisse/ch-epr-fhir/branches/371-add-a-tracecontext-entity-to-atc-auditevent-examples/qa.html