### PR TITLE
Add closed issues section to changelog

### DIFF
--- a/input/pagecontent/changelog.md
+++ b/input/pagecontent/changelog.md
@@ -27,10 +27,10 @@
 * ATC: add Tracecontext values to ATC examples [#371](https://github.com/ehealthsuisse/ch-epr-fhir/issues/371)
 
 #### Closed Issues
-* IHE PCF not a replacement for CH:PPQ/CH:ADR [#388](https://github.com/ehealthsuisse/ch-epr-fhir/issues/388)
-* ATC_LOG_READ required by Annex 2 [#390](https://github.com/ehealthsuisse/ch-epr-fhir/issues/390)
-* Binding DocumentReference.securityLabel not changed sind binding in R5 less strict [#386](https://github.com/ehealthsuisse/ch-epr-fhir/issues/386)
-* No extended AuditEvent for CH:ADR decision logging [#356](https://github.com/ehealthsuisse/ch-epr-fhir/issues/356)
+* CH:PPQ: IHE PCF not a replacement for CH:PPQ/CH:ADR [#388](https://github.com/ehealthsuisse/ch-epr-fhir/issues/388)
+* ATC: ATC_LOG_READ, ATC_DOC_* required by Annex 2 [#390](https://github.com/ehealthsuisse/ch-epr-fhir/issues/390), [#389](https://github.com/ehealthsuisse/ch-epr-fhir/issues/389)
+* ATC: No extended AuditEvent for CH:ADR decision logging [#356](https://github.com/ehealthsuisse/ch-epr-fhir/issues/356)
+* MHD: Binding DocumentReference.securityLabel not changed sind binding in R5 less strict [#386](https://github.com/ehealthsuisse/ch-epr-fhir/issues/386)
 
 ### DSTU5 Informative Ballot 2025 
 


### PR DESCRIPTION
## Summary
* Added new "Closed Issues" section to the DSTU5 Informative Ballot upcoming 2025 Release in the changelog
* Documents issues #388, #390, #386, and #356 that were closed without requiring implementation changes

## Issues Included
* **#388**: Consider IHE PCF - Closed as IHE PCF is not a replacement for CH:PPQ/CH:ADR
* **#390**: ATC_LOG_READ duplicative of ITI-81 - Closed as ATC_LOG_READ is required by Annex 2
* **#386**: Bind DocumentReference.securityLabel - Closed as binding in R5 is less strict
* **#356**: Extend AuditEvent profile for CH:ADR decision logging - Closed as no extended AuditEvent will be implemented