### PR TITLE
Update HTTP signature algorithm requirements

### DIFF
--- a/input/pagecontent/iti-71.md
+++ b/input/pagecontent/iti-71.md
@@ -613,6 +613,9 @@ Content-Digest: sha-512=:Lh6fzO9XALiY46o5xVyN9yZloKZ6pLJV0kz+VirU5b6rQd2ii7vrTt4
 
 IUA Authorization Server SHALL verify the signature of the token requests as specified in `RFC 9421 HTTP Message Signatures`.
 
+IUA Authorization Servers SHALL NOT implement any algorithm using a shared key (for example _HMAC_), and they SHALL 
+implement at least the algorithm 'RSASSA-PKCS1-v1_5 Using SHA-256'.
+
 When receiving requests of transactions where the EPR-SPID is provided in the IUA token and in the transaction body,
 the IUA Resource Servers SHALL verify that both are the same.
 


### PR DESCRIPTION
This completes what was asked in PR #433.

The reasoning is as follows:

- We need to forbid shared key algorithms. Otherwise, the 'Non-repudiation' [requirement](https://github.com/ehealthsuisse/ch-epr-fhir/issues/419) doesn't hold because the server has the same key as the client, and can forge any signature.
- Requiring at least one algorithm to be implemented allows a software provider to implement one algorithm that will be supported by all communities, instead of having to implement one algo per community.
- 'RSASSA-PKCS1-v1_5 Using SHA-256' is the same algorithm as the one commonly used to sign TCU assertions (`http://www.w3.org/2001/04/xmldsig-more#rsa-sha256`, [spec](https://www.ietf.org/rfc/rfc4051.txt)), and is still recommended in [JWA](https://datatracker.ietf.org/doc/html/rfc7518#section-3.1)). But we could also go with the newer 'ECDSA Using Curve P-256 DSS and SHA-256', also recommended in JWA (and is foreseen to be upgraded to 'required' in the future).
- Servers MAY implement other algorithms if they have specific needs.